### PR TITLE
feat: Redefine toric varieties and show the torus is a toric variety

### DIFF
--- a/Toric/MonoidObjectAction/Global.lean
+++ b/Toric/MonoidObjectAction/Global.lean
@@ -1,0 +1,6 @@
+import Toric.Mathlib.CategoryTheory.Monoidal.Mon_
+import Mathlib.Algebra.Category.Grp.Adjunctions
+import Mathlib.Algebra.Category.Ring.Adjunctions
+import Mathlib.AlgebraicGeometry.Limits
+import Mathlib.CategoryTheory.Adjunction.Opposites
+import Mathlib.CategoryTheory.Monoidal.Yoneda

--- a/Toric/ToricVariety/Defs.lean
+++ b/Toric/ToricVariety/Defs.lean
@@ -1,11 +1,13 @@
 /-
 Copyright (c) 2025 Yaël Dillies, Patrick Luo, Michał Mrugała. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Yaël Dillies, Patrick Luo, Michał Mrugała
+Authors: Yaël Dillies, Patrick Luo, Michał Mrugała, Paul Lezeau
 -/
 import Mathlib.AlgebraicGeometry.Morphisms.UnderlyingMap
 import Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback
 import Toric.GroupScheme.Torus
+import Toric.Torus
+import Toric.MonoidObjectAction.Basic
 
 /-!
 # Toric varieties
@@ -14,18 +16,49 @@ This file defines a toric variety over a ring `R` as a scheme `X` with a structu
 `Spec R`.
 -/
 
+open CategoryTheory Limits
+open CategoryTheory Mon_Class MonoidalCategory
 open CategoryTheory ChosenFiniteProducts Limits AlgebraicGeometry.Scheme
 open scoped Mon_Class MonoidalCategory
-
 namespace AlgebraicGeometry
 universe u
 variable {R : CommRingCat.{u}} {n : ℕ}
 
 attribute [local instance] ChosenFiniteProducts.ofFiniteProducts
 
+open Action_Class
+
 --TODO: add group action axioms
 --TODO: make a general definition of a group object action
 variable (R n)
+-- /-- A toric variety of dimension `n` over a ring `R` is a scheme `X` equipped with a dense
+--embedding
+-- `Tⁿ → X` and an action `T × X → X` extending the standard action `T × T → T`. -/
+-- class ToricVariety (X : Scheme) extends X.Over (Spec R) where
+--   /-- The torus embedding -/
+--   torusEmb : Torus R n ⟶ X
+--   /-- The torus embedding is a morphism over `Spec R`. -/
+--   torusEmb_comp_overHom : HomIsOver torusEmb (Spec R) := by aesop_cat
+--   /-- The torus embedding is an open immersion. -/
+--   [isOpenImmersion_torusEmb : IsOpenImmersion torusEmb]
+--   /-- The torus embedding is dominant. -/
+--   [isDominant_torusEmb : IsDominant torusEmb]
+--   [torusAct : Action_Class (torusOver R n) (X.asOver <| Spec R)]
+--   /- The torus action on a toric variety. -/
+--   --torusAct : pullback (Torus R n ↘ Spec R) (X ↘ Spec R) ⟶ X
+--   /-- The torus action extends the torus multiplication morphism. -/
+--   torusMul_comp_torusEmb : (𝟙 (torusOver R n)) ⊗ (Scheme.Hom.asOver torusEmb (Spec R)) ≫
+--       (γ : (torusOver R n) ⊗ (X.asOver <| Spec R) ⟶ (X.asOver <| Spec R)) =
+--         μ[(torusOver R n)] ≫ (Scheme.Hom.asOver torusEmb (Spec R))
+--     -- torusMul ≫
+--     -- torusEmb = pullback.lift (pullback.fst _ _) (pullback.snd _ _ ≫ torusEmb)
+--     --             (by simp [pullback.condition, torusEmb_comp_overHom]) ≫
+--     -- torusAct := by aesop_cat
+--   /-There is a monoid action of the torus on `X` -/
+--  --torusAction : Action_Class (torusOver R n) (X.asOver <| Spec R)
+--   /-- The torus action is compatible with the torus embedding -/
+--   t : Bool
+
 /-- A toric variety of dimension `n` over a ring `R` is a scheme `X` equipped with a dense embedding
 `Tⁿ → X` and an action `T × X → X` extending the standard action `T × T → T`. -/
 class ToricVariety (X : Over <| Spec R) where
@@ -36,13 +69,14 @@ class ToricVariety (X : Over <| Spec R) where
   /-- The torus embedding is dominant. -/
   [isDominant_torusEmb : IsDominant torusEmb.left]
   /-- The torus action on a toric variety. -/
-  torusAct : 𝔾ₘ[R, n] ⊗ X ⟶ X
+  [torusAct : Action_Class (torusOver R n) X]
   /-- The torus action extends the torus multiplication morphism. -/
-  torusMul_comp_torusEmb : μ ≫ torusEmb = lift (fst _ _) (snd _ _ ≫ torusEmb) ≫ torusAct := by
-    aesop_cat
+  torusMul_comp_torusEmb : (𝟙 (torusOver R n) ⊗ torusEmb) ≫ γ =  μ[torusOver R n] ≫ torusEmb :=
+    by aesop_cat
 
-noncomputable instance : ToricVariety R n 𝔾ₘ[R, n] where
-  torusEmb := 𝟙 _
-  torusAct := μ
+
+noncomputable instance : ToricVariety R n (torusOver R n) where
+  torusEmb := 𝟙 ((torusOver R n))
+  torusAct := selfAction _
 
 end AlgebraicGeometry

--- a/Toric/ToricVariety/Defs.lean
+++ b/Toric/ToricVariety/Defs.lean
@@ -6,7 +6,6 @@ Authors: Yaël Dillies, Patrick Luo, Michał Mrugała, Paul Lezeau
 import Mathlib.AlgebraicGeometry.Morphisms.UnderlyingMap
 import Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback
 import Toric.GroupScheme.Torus
-import Toric.Torus
 import Toric.MonoidObjectAction.Basic
 
 /-!
@@ -22,7 +21,7 @@ open CategoryTheory ChosenFiniteProducts Limits AlgebraicGeometry.Scheme
 open scoped Mon_Class MonoidalCategory
 namespace AlgebraicGeometry
 universe u
-variable {R : CommRingCat.{u}} {n : ℕ}
+variable {R : CommRingCat.{u}} (n : ℕ)
 
 attribute [local instance] ChosenFiniteProducts.ofFiniteProducts
 
@@ -38,14 +37,14 @@ class ToricVariety (X : Over <| Spec R) where
   /-- The torus embedding is dominant. -/
   [isDominant_torusEmb : IsDominant torusEmb.left]
   /-- The torus action on a toric variety. -/
-  [torusAct : Action_Class (torusOver R n) X]
+  [torusAct : Action_Class 𝔾ₘ[R, n] X]
   /-- The torus action extends the torus multiplication morphism. -/
-  torusMul_comp_torusEmb : (𝟙 (torusOver R n) ⊗ torusEmb) ≫ γ =  μ[torusOver R n] ≫ torusEmb :=
+  torusMul_comp_torusEmb : (𝟙 (𝔾ₘ[R, n]) ⊗ torusEmb) ≫ γ =  μ[𝔾ₘ[R, n]] ≫ torusEmb :=
     by aesop_cat
 
 
-noncomputable instance : ToricVariety R n (torusOver R n) where
-  torusEmb := 𝟙 ((torusOver R n))
+noncomputable instance : ToricVariety n 𝔾ₘ[R, n] where
+  torusEmb := 𝟙 𝔾ₘ[R, n]
   torusAct := selfAction _
 
 end AlgebraicGeometry

--- a/Toric/ToricVariety/Defs.lean
+++ b/Toric/ToricVariety/Defs.lean
@@ -28,37 +28,6 @@ attribute [local instance] ChosenFiniteProducts.ofFiniteProducts
 
 open Action_Class
 
---TODO: add group action axioms
---TODO: make a general definition of a group object action
-variable (R n)
--- /-- A toric variety of dimension `n` over a ring `R` is a scheme `X` equipped with a dense
---embedding
--- `Tⁿ → X` and an action `T × X → X` extending the standard action `T × T → T`. -/
--- class ToricVariety (X : Scheme) extends X.Over (Spec R) where
---   /-- The torus embedding -/
---   torusEmb : Torus R n ⟶ X
---   /-- The torus embedding is a morphism over `Spec R`. -/
---   torusEmb_comp_overHom : HomIsOver torusEmb (Spec R) := by aesop_cat
---   /-- The torus embedding is an open immersion. -/
---   [isOpenImmersion_torusEmb : IsOpenImmersion torusEmb]
---   /-- The torus embedding is dominant. -/
---   [isDominant_torusEmb : IsDominant torusEmb]
---   [torusAct : Action_Class (torusOver R n) (X.asOver <| Spec R)]
---   /- The torus action on a toric variety. -/
---   --torusAct : pullback (Torus R n ↘ Spec R) (X ↘ Spec R) ⟶ X
---   /-- The torus action extends the torus multiplication morphism. -/
---   torusMul_comp_torusEmb : (𝟙 (torusOver R n)) ⊗ (Scheme.Hom.asOver torusEmb (Spec R)) ≫
---       (γ : (torusOver R n) ⊗ (X.asOver <| Spec R) ⟶ (X.asOver <| Spec R)) =
---         μ[(torusOver R n)] ≫ (Scheme.Hom.asOver torusEmb (Spec R))
---     -- torusMul ≫
---     -- torusEmb = pullback.lift (pullback.fst _ _) (pullback.snd _ _ ≫ torusEmb)
---     --             (by simp [pullback.condition, torusEmb_comp_overHom]) ≫
---     -- torusAct := by aesop_cat
---   /-There is a monoid action of the torus on `X` -/
---  --torusAction : Action_Class (torusOver R n) (X.asOver <| Spec R)
---   /-- The torus action is compatible with the torus embedding -/
---   t : Bool
-
 /-- A toric variety of dimension `n` over a ring `R` is a scheme `X` equipped with a dense embedding
 `Tⁿ → X` and an action `T × X → X` extending the standard action `T × T → T`. -/
 class ToricVariety (X : Over <| Spec R) where

--- a/Toric/ToricVariety/FromMonoid.lean
+++ b/Toric/ToricVariety/FromMonoid.lean
@@ -23,7 +23,7 @@ noncomputable abbrev AffineToricVarietyFromMonoid : Over <| Spec R :=
 namespace AffineToricVarietyFromMonoid
 
 noncomputable instance instToricVariety :
-    ToricVariety R (dim S) (AffineToricVarietyFromMonoid R S) where
+    ToricVariety (dim S) (AffineToricVarietyFromMonoid R S) where
   torusEmb := (splitTorusIsoSpecOver _ _).hom ≫ (Over.homMk
     (Spec.map (CommRingCat.ofHom (AddMonoidAlgebra.mapDomainRingHom R <| embedding S))) <| by
     change Spec.map _ ≫ Spec.map _ = Spec.map _


### PR DESCRIPTION
This PR redefines toric varieties in terms of the `Over (Spec R)` category and proves that the torus is a toric variety. It would be nice to also have a definition that works in the category `Scheme` (i.e. the previous one that I've just commented out for now), but maybe this can be left to future work since this will require defining the non-relative version of a monoid object action.