### PR TITLE
refactor: redefine `ToricVariety` to be about bare schemes

### DIFF
--- a/Toric/GroupScheme/Torus.lean
+++ b/Toric/GroupScheme/Torus.lean
@@ -98,20 +98,16 @@ def SplitTorus.representableBy (S : Scheme) (σ : Type*) :
         (isoWhiskerLeft ((Over.forget _).op ⋙ Scheme.Γ ⋙ forget₂ _ CommMonCat ⋙
           CommMonCat.units ⋙ forget CommGrp) (Coyoneda.opIso.app _))
 
-/-- The split torus of dimension `n` over `Spec R`. -/
-notation "𝔾ₘ[" R ", " n "]" => Over.mk (SplitTorus (Spec R) (ULift <| Fin n) ↘ Spec R)
+/-- The split torus of dimension `σ` over `Spec R`. -/
+notation "𝔾ₘ[" R ", " σ "]" => Over.mk (SplitTorus (Spec R) σ ↘ Spec R)
 
 /-- The split torus with dimensions `σ` over `Spec R` is isomorphic to `Spec R[ℤ^σ]`. -/
 def splitTorusIsoSpec (R : CommRingCat) (σ : Type*) :
     SplitTorus (Spec R) σ ≅ Spec (.of <| MvLaurentPolynomial σ R) := sorry
 
 /-- The split torus of dimension `n` over `Spec R` is isomorphic to `Spec R[ℤⁿ]`. -/
-def splitTorusIsoSpecOver (R : CommRingCat) (n : ℕ) :
-    𝔾ₘ[R, n] ≅
-      .mk <| Spec.map <| CommRingCat.ofHom <| algebraMap R (MvLaurentPolynomial (Fin n) R) :=
-  Over.isoMk
-    ((splitTorusIsoSpec _ _).trans <| Scheme.Spec.mapIso <| .op <| RingEquiv.toCommRingCatIso <|
-      (AddMonoidAlgebra.domCongr R _ <| FreeAbelianGroup.equivOfEquiv Equiv.ulift.symm).toRingEquiv)
-    sorry
+def splitTorusIsoSpecOver (R : CommRingCat) (σ : Type*) :
+    𝔾ₘ[R, σ] ≅ .mk <| Spec.map <| CommRingCat.ofHom <| algebraMap R (MvLaurentPolynomial σ R) :=
+  Over.isoMk (splitTorusIsoSpec _ _) sorry
 
 end AlgebraicGeometry.Scheme

--- a/Toric/ToricVariety/Defs.lean
+++ b/Toric/ToricVariety/Defs.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2025 Yaël Dillies, Patrick Luo, Michał Mrugała. All rights reserved.
+Copyright (c) 2025 Yaël Dillies, Paul Lezeau, Patrick Luo, Michał Mrugała. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Yaël Dillies, Patrick Luo, Michał Mrugała, Paul Lezeau
+Authors: Yaël Dillies, Paul Lezeau, Patrick Luo, Michał Mrugała
 -/
 import Mathlib.AlgebraicGeometry.Morphisms.UnderlyingMap
 import Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback
@@ -15,10 +15,8 @@ This file defines a toric variety over a ring `R` as a scheme `X` with a structu
 `Spec R`.
 -/
 
-open CategoryTheory Limits
-open CategoryTheory Mon_Class MonoidalCategory
-open CategoryTheory ChosenFiniteProducts Limits AlgebraicGeometry.Scheme
-open scoped Mon_Class MonoidalCategory
+open CategoryTheory Mon_Class MonoidalCategory ChosenFiniteProducts Limits AlgebraicGeometry.Scheme
+
 namespace AlgebraicGeometry
 universe u
 variable {R : CommRingCat.{u}} (σ : Type u)
@@ -27,26 +25,22 @@ attribute [local instance] ChosenFiniteProducts.ofFiniteProducts
 
 open Mon_Class
 
+variable (R) in
 /-- A toric variety of dimension `n` over a ring `R` is a scheme `X` equipped with a dense embedding
 `Tⁿ → X` and an action `T × X → X` extending the standard action `T × T → T`. -/
-class ToricVariety (X : Over <| Spec R) where
-  /-- The torus embedding -/
-  torusEmb : Over.mk (SplitTorus (Spec R) σ ↘ Spec R) ⟶ X
+class ToricVariety (X : Scheme)
+    extends X.Over (Spec R), Mod_Class 𝔾ₘ[R, σ] (.mk (X ↘ Spec R)) where
+  /-- The torus embedding. -/
+  torusEmb : 𝔾ₘ[R, σ] ⟶ .mk (X ↘ Spec R)
   /-- The torus embedding is an open immersion. -/
   [isOpenImmersion_torusEmb : IsOpenImmersion torusEmb.left]
   /-- The torus embedding is dominant. -/
   [isDominant_torusEmb : IsDominant torusEmb.left]
-  /-- The torus action on a toric variety. -/
-  [torusAct : Mod_Class (Over.mk (SplitTorus (Spec R) σ ↘ Spec R)) X]
   /-- The torus action extends the torus multiplication morphism. -/
-  torusMul_comp_torusEmb :
-      (𝟙 (Over.mk (SplitTorus (Spec R) σ ↘ Spec R)) ⊗ torusEmb) ≫ γ
-      =  μ[Over.mk (SplitTorus (Spec R) σ ↘ Spec R)] ≫ torusEmb :=
-    by aesop_cat
+  torusMul_comp_torusEmb : (𝟙 𝔾ₘ[R, σ] ⊗ torusEmb) ≫ γ =  μ[𝔾ₘ[R, σ]] ≫ torusEmb := by aesop_cat
 
-
-noncomputable instance : ToricVariety σ (Over.mk (SplitTorus (Spec R) σ ↘ Spec R)) where
-  torusEmb := 𝟙 (Over.mk (SplitTorus (Spec R) σ ↘ Spec R))
-  torusAct := .regular _
+noncomputable instance : ToricVariety R σ 𝔾ₘ[R, σ].left where
+  toMod_Class := .regular _
+  torusEmb := 𝟙 _
 
 end AlgebraicGeometry

--- a/Toric/ToricVariety/Defs.lean
+++ b/Toric/ToricVariety/Defs.lean
@@ -21,8 +21,7 @@ open CategoryTheory ChosenFiniteProducts Limits AlgebraicGeometry.Scheme
 open scoped Mon_Class MonoidalCategory
 namespace AlgebraicGeometry
 universe u
-variable {R : CommRingCat.{u}} (n : ℕ)
--- probably want to use a f.g. abelian group rather than n
+variable {R : CommRingCat.{u}} (σ : Type u)
 
 attribute [local instance] ChosenFiniteProducts.ofFiniteProducts
 
@@ -32,20 +31,22 @@ open Mon_Class
 `Tⁿ → X` and an action `T × X → X` extending the standard action `T × T → T`. -/
 class ToricVariety (X : Over <| Spec R) where
   /-- The torus embedding -/
-  torusEmb : 𝔾ₘ[R, n] ⟶ X
+  torusEmb : Over.mk (SplitTorus (Spec R) σ ↘ Spec R) ⟶ X
   /-- The torus embedding is an open immersion. -/
   [isOpenImmersion_torusEmb : IsOpenImmersion torusEmb.left]
   /-- The torus embedding is dominant. -/
   [isDominant_torusEmb : IsDominant torusEmb.left]
   /-- The torus action on a toric variety. -/
-  [torusAct : Mod_Class 𝔾ₘ[R, n] X]
+  [torusAct : Mod_Class (Over.mk (SplitTorus (Spec R) σ ↘ Spec R)) X]
   /-- The torus action extends the torus multiplication morphism. -/
-  torusMul_comp_torusEmb : (𝟙 (𝔾ₘ[R, n]) ⊗ torusEmb) ≫ γ =  μ[𝔾ₘ[R, n]] ≫ torusEmb :=
+  torusMul_comp_torusEmb :
+      (𝟙 (Over.mk (SplitTorus (Spec R) σ ↘ Spec R)) ⊗ torusEmb) ≫ γ
+      =  μ[Over.mk (SplitTorus (Spec R) σ ↘ Spec R)] ≫ torusEmb :=
     by aesop_cat
 
 
-noncomputable instance : ToricVariety n 𝔾ₘ[R, n] where
-  torusEmb := 𝟙 𝔾ₘ[R, n]
+noncomputable instance : ToricVariety σ (Over.mk (SplitTorus (Spec R) σ ↘ Spec R)) where
+  torusEmb := 𝟙 (Over.mk (SplitTorus (Spec R) σ ↘ Spec R))
   torusAct := .regular _
 
 end AlgebraicGeometry

--- a/Toric/ToricVariety/FromMonoid.lean
+++ b/Toric/ToricVariety/FromMonoid.lean
@@ -5,11 +5,14 @@ Authors: Patrick Luo
 -/
 import Mathlib.RingTheory.Bialgebra.Basic
 import Toric.AffineMonoid.Embedding
+import Toric.GroupScheme.HopfAffine
 import Toric.ToricVariety.Defs
 
 /-!
 # Affine monoids give rise to toric varieties
 -/
+
+noncomputable section
 
 open AlgebraicGeometry Scheme CategoryTheory Limits AddMonoidAlgebra AddLocalization AffineMonoid
 
@@ -23,16 +26,20 @@ noncomputable abbrev AffineToricVarietyFromMonoid : Over <| Spec R :=
 
 namespace AffineToricVarietyFromMonoid
 
-instance instToricVariety :
-    Mod_Class 𝔾ₘ[R, ULift <| Fin <| dim S] (.mk (Spec (.of R[S]) ↘ Spec R)) where
+-- TODO: This used to be nicer when the torus was defined as `Spec _`
+instance instMod_Class :
+    Mod_Class 𝔾ₘ[R, ULift <| Fin <| dim S] ((algSpec R).obj <| .op <| .of R R[S]) where
+  smul := Over.homMk sorry sorry
+  -- (pullbackSpecIso _ _ _).hom ≫ (Spec.map <| CommRingCat.ofHom <| RingHom.comp
+  -- (Algebra.TensorProduct.map (AddMonoidAlgebra.mapDomainAlgHom R _ <| embedding S)
+  --   (.id _ _)).toRingHom (Bialgebra.comulAlgHom R _).toRingHom)
+  one_smul := sorry
+  mul_smul := sorry
 
 noncomputable instance instToricVariety :
     ToricVariety R (ULift <| Fin <| dim S) (Spec <| .of R[S]) where
+  __ := instMod_Class
   hom := Spec.map <| CommRingCat.ofHom <| algebraMap R R[S]
-  smul := sorry
-    -- (pullbackSpecIso _ _ _).hom ≫ (Spec.map <| CommRingCat.ofHom <| RingHom.comp
-    -- (Algebra.TensorProduct.map (AddMonoidAlgebra.mapDomainAlgHom R _ <| embedding S)
-    --   (.id _ _)).toRingHom (Bialgebra.comulAlgHom R _).toRingHom)
   torusEmb := sorry
     -- (splitTorusIsoSpecOver _ _).hom ≫ (Over.homMk
     -- (Spec.map (CommRingCat.ofHom (AddMonoidAlgebra.mapDomainRingHom R <| embedding S))) <| by

--- a/Toric/ToricVariety/FromMonoid.lean
+++ b/Toric/ToricVariety/FromMonoid.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 Patrick Luo. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Luo
 -/
+import Mathlib.RingTheory.Bialgebra.Basic
 import Toric.AffineMonoid.Embedding
 import Toric.ToricVariety.Defs
 
@@ -22,15 +23,24 @@ noncomputable abbrev AffineToricVarietyFromMonoid : Over <| Spec R :=
 
 namespace AffineToricVarietyFromMonoid
 
+instance instToricVariety :
+    Mod_Class 𝔾ₘ[R, ULift <| Fin <| dim S] (.mk (Spec (.of R[S]) ↘ Spec R)) where
+
 noncomputable instance instToricVariety :
-    ToricVariety (dim S) (AffineToricVarietyFromMonoid R S) where
-  torusEmb := (splitTorusIsoSpecOver _ _).hom ≫ (Over.homMk
-    (Spec.map (CommRingCat.ofHom (AddMonoidAlgebra.mapDomainRingHom R <| embedding S))) <| by
-    change Spec.map _ ≫ Spec.map _ = Spec.map _
-    simp [← Spec.map_comp, ← CommRingCat.ofHom_comp]
-    congr! 2
-    ext
-    simp)
+    ToricVariety R (ULift <| Fin <| dim S) (Spec <| .of R[S]) where
+  hom := Spec.map <| CommRingCat.ofHom <| algebraMap R R[S]
+  smul := sorry
+    -- (pullbackSpecIso _ _ _).hom ≫ (Spec.map <| CommRingCat.ofHom <| RingHom.comp
+    -- (Algebra.TensorProduct.map (AddMonoidAlgebra.mapDomainAlgHom R _ <| embedding S)
+    --   (.id _ _)).toRingHom (Bialgebra.comulAlgHom R _).toRingHom)
+  torusEmb := sorry
+    -- (splitTorusIsoSpecOver _ _).hom ≫ (Over.homMk
+    -- (Spec.map (CommRingCat.ofHom (AddMonoidAlgebra.mapDomainRingHom R <| embedding S))) <| by
+    -- change Spec.map _ ≫ Spec.map _ = Spec.map _
+    -- simp [← Spec.map_comp, ← CommRingCat.ofHom_comp]
+    -- congr! 2
+    -- ext
+    -- simp)
   isOpenImmersion_torusEmb := by
     stop
     obtain ⟨s, hsgen⟩ := AddMonoid.FG.fg_top (N := S)
@@ -46,11 +56,6 @@ noncomputable instance instToricVariety :
     have img_domain := Subring.instIsDomainSubtypeMem img
     have := (AlgebraicGeometry.affine_isIntegral_iff (CommRingCat.of (AddMonoidAlgebra R S)))
     sorry
-  torusAct :=
-    sorry
-    -- (pullbackSpecIso _ _ _).hom ≫ (Spec.map <| CommRingCat.ofHom <| RingHom.comp
-    -- (Algebra.TensorProduct.map (AddMonoidAlgebra.mapDomainAlgHom R _ <| embedding S)
-    --   (.id _ _)).toRingHom (Bialgebra.comulAlgHom R _).toRingHom)
   torusMul_comp_torusEmb := by
     stop
     simp [← Spec.map_comp, ← CommRingCat.ofHom_comp, pullback.condition]

--- a/Toric/ToricVariety/FromMonoid.lean
+++ b/Toric/ToricVariety/FromMonoid.lean
@@ -20,10 +20,6 @@ universe u
 variable {R : CommRingCat.{u}} [IsDomain R] {S : Type u} [AddCancelCommMonoid S] [AddMonoid.FG S]
   [IsAddTorsionFree S]
 
-variable (R S) in
-noncomputable abbrev AffineToricVarietyFromMonoid : Over <| Spec R :=
-  .mk <| Spec.map <| CommRingCat.ofHom <| algebraMap R R[S]
-
 namespace AffineToricVarietyFromMonoid
 
 -- TODO: This used to be nicer when the torus was defined as `Spec _`

--- a/Toric/ToricVariety/FromMonoid.lean
+++ b/Toric/ToricVariety/FromMonoid.lean
@@ -3,7 +3,6 @@ Copyright (c) 2025 Patrick Luo. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Luo
 -/
-import Mathlib.RingTheory.Bialgebra.Basic
 import Toric.AffineMonoid.Embedding
 import Toric.GroupScheme.HopfAffine
 import Toric.ToricVariety.Defs


### PR DESCRIPTION
I'm not entirely happy with this, the notation feels clunky. I think we might want to refactor the definition of a torus to come from a free abelian group in the first place.