### PR TITLE
Generalise faithfulness of Diag to an arbitrary base

### DIFF
--- a/Toric.lean
+++ b/Toric.lean
@@ -20,6 +20,8 @@ import Toric.Mathlib.Algebra.MonoidAlgebra.MapDomain
 import Toric.Mathlib.Algebra.MonoidAlgebra.Module
 import Toric.Mathlib.Algebra.Polynomial.Bivariate
 import Toric.Mathlib.AlgebraicGeometry.Pullbacks
+import Toric.Mathlib.CategoryTheory.Comma.Over.Basic
+import Toric.Mathlib.CategoryTheory.Comma.Over.Pullback
 import Toric.Mathlib.CategoryTheory.Limits.Preserves.Shapes.Over
 import Toric.Mathlib.CategoryTheory.Monoidal.Attr
 import Toric.Mathlib.CategoryTheory.Monoidal.Cartesian.Basic

--- a/Toric/GroupScheme/Diagonalizable.lean
+++ b/Toric/GroupScheme/Diagonalizable.lean
@@ -9,6 +9,7 @@ import Mathlib.AlgebraicGeometry.Morphisms.FiniteType
 import Mathlib.CategoryTheory.Limits.Shapes.Pullback.Pasting
 import Toric.GroupScheme.MonoidAlgebra
 import Toric.Mathlib.Algebra.Group.TypeTags.Hom
+import Toric.Mathlib.CategoryTheory.Comma.Over.Pullback
 
 open AlgebraicGeometry CategoryTheory Bialgebra Opposite Limits
 open scoped AddMonoidAlgebra Mon_Class
@@ -165,6 +166,12 @@ def diagFunctor : AddCommGrpᵒᵖ ⥤ Grp_ (Over S) :=
 @[simp] lemma diagFunctor_map {M N : AddCommGrpᵒᵖ} (f : M ⟶ N) :
     (diagFunctor S).map f = ⟨(Diag.map S f.unop.hom).asOver S⟩ := rfl
 
+instance : (diagFunctor S).Faithful := by
+  have : (hopfSpec (.of <| ULift.{u} ℤ)).Faithful := hopfSpec.instFaithful
+  have (Z) (g : Z ⟶ Spec(ULift.{u} ℤ)) : Epi (pullback.fst g (specULiftZIsTerminal.from S)) := sorry
+  unfold diagFunctor
+  infer_instance
+
 instance (M : AddCommMonCatᵒᵖ) : IsCommMon ((diagMonFunctor S).obj M).X :=
   inferInstanceAs (IsCommMon (asOver (Diag S M.unop) S))
 
@@ -220,10 +227,6 @@ def diagFunctorIso :
 
 lemma diagFunctorIso_app (M : AddCommGrpᵒᵖ) :
     ((diagFunctorIso R).app M).hom.hom.left = (diagSpecIso R M.unop).hom := rfl
-
-instance {R : Type*} [CommRing R] [Nontrivial R] : (diagFunctor Spec(R)).Faithful :=
-  have : (hopfSpec (CommRingCat.of R)).Faithful := hopfSpec.instFaithful
-  .of_iso (diagFunctorIso (.of R)).symm
 
 instance {R : Type*} [CommRing R] [IsDomain R] : (diagFunctor Spec(R)).Full :=
   have : (hopfSpec (CommRingCat.of R)).Full := hopfSpec.instFull

--- a/Toric/Mathlib/CategoryTheory/Comma/Over/Basic.lean
+++ b/Toric/Mathlib/CategoryTheory/Comma/Over/Basic.lean
@@ -1,0 +1,9 @@
+import Mathlib.CategoryTheory.Comma.Over.Basic
+
+namespace CategoryTheory.Over
+universe v
+variable {C : Type*} [Category.{v} C] {X : C} {U V : Over X} {f : U.left ⟶ V.left}
+
+instance epi_homMk [Epi f] (w) : Epi (homMk f w) := (forget X).epi_of_epi_map ‹_›
+
+end CategoryTheory.Over

--- a/Toric/Mathlib/CategoryTheory/Comma/Over/Pullback.lean
+++ b/Toric/Mathlib/CategoryTheory/Comma/Over/Pullback.lean
@@ -1,0 +1,23 @@
+import Mathlib.CategoryTheory.Adjunction.FullyFaithful
+import Mathlib.CategoryTheory.Comma.Over.Pullback
+import Toric.Mathlib.CategoryTheory.Comma.Over.Basic
+
+namespace CategoryTheory.Over
+
+open Limits
+
+universe v
+variable {C : Type*} [Category.{v} C] [HasPullbacks C] {X Y : C} {f : X ⟶ Y}
+
+/-- The pullback along an epi that's preserved under pullbacks is faithful.
+
+This "preserved under" pullbacks" condition is automatically satisfied in abelian categories:
+```
+example [Abelian C] [Epi f] : (pullback f).Faithful := inferInstance
+```
+-/
+instance faithful_pullback [∀ Z (g : Z ⟶ Y), Epi (pullback.fst g f)] : (pullback f).Faithful := by
+  have (Z : Over Y) : Epi ((mapPullbackAdj f).counit.app Z) := by simp; infer_instance
+  exact (mapPullbackAdj f).faithful_R_of_epi_counit_app
+
+end CategoryTheory.Over


### PR DESCRIPTION
I have reduced this to showing that `specULiftZIsTerminal.from S` is still epi after an arbitrary pullback.